### PR TITLE
Add noscript fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   
   <script async defer data-website-id="76d81b09-7700-4d43-bd2c-1a28cd3dd5ff" src="https://analytics.rail.works/script.js"></script>
   <link rel="stylesheet" href="index.css">
+  <noscript><style> .jsonly { display: none } </style></noscript>
 </head>
 
 <body>
@@ -27,9 +28,14 @@
                 Roblox documents showcasing the deep truth they don't want you to know. The cold hard truth.</p>
               <p class="mt-6 text-lg text-gray-700 italic">This site is not owned by Roblox and does not endorse any of
                 the content shown here.</p>
+              <!-- Standard javascript-enabled button -->
               <button type="button" id="activate" onClick="startVideo()" data-umami-event="Click Activate Button"
-                class="inline-flex items-center px-4 py-2 mt-7 border border-transparent text-lg font-medium rounded-full shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Learn
+                class="jsonly inline-flex items-center px-4 py-2 mt-7 border border-transparent text-lg font-medium rounded-full shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Learn
                 the truth</button>
+              <!-- Fallback redirect button if javascript isn't available -->
+              <noscript><a type="button" href="/the-truth"
+                class="inline-flex items-center px-4 py-2 mt-7 border border-transparent text-lg font-medium rounded-full shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Learn
+                the truth</a></noscript>
             </div>
           </div>
         </div>

--- a/the-truth.html
+++ b/the-truth.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Roblox.exposed - The Truth</title>
+  <meta name="description" content="Exposing the cold hard truth about Roblox.">
+  <script async defer data-website-id="76d81b09-7700-4d43-bd2c-1a28cd3dd5ff" src="https://analytics.rail.works/analytics.js"></script>
+  <meta http-equiv="refresh" content="0; url=https://www.youtube.com/embed/GtL1huin9EE?autoplay=1"/>
+</head>


### PR DESCRIPTION
This change adds a fallback "Learn the truth" href button if javascript isn't available. 
The button links to "/the-truth", which redirects to the youtube video. (Doing this masks the actual link the user will end up in)

the-truth.html can be removed if the redirect is set up properly in the webserver.


https://github.com/railworks2rblx/roblox.exposed/assets/55360900/fa3b6485-82cf-4225-b5fb-45516af9100b


